### PR TITLE
Make MySQL 8.X-compatible, QoL improvements

### DIFF
--- a/constants.rb
+++ b/constants.rb
@@ -1,1 +1,10 @@
+# Days that students are required to be in the lab. If as student signs in on
+# one of these days, all other students will be marked missing on the calendar
+# if they are not present. Conversely, if a student signs in on a day not in
+# this list, an optional build will be created for that day.
 REQUIRED_BUILD_DAYS = ["Monday", "Wednesday", "Friday", "Saturday"]
+
+# The time zone that end users will be in (all times will be presented in
+# this time zone). Some queries make assumptions about time zone and may
+# need to be edited if used outside California.
+USER_TIME_ZONE = "America/Los_Angeles"

--- a/queries.rb
+++ b/queries.rb
@@ -1,106 +1,82 @@
 BUILD_DAYS_QUERY = """
+WITH
+    build_days AS (SELECT DISTINCT DATE(time_in) AS build_date FROM cheesy_frc_hours.lab_sessions)
 SELECT
     build_days.build_date,
     NOT ISNULL(cheesy_frc_hours.optional_builds.date) AS optional
 FROM
-    (SELECT DISTINCT DATE(DATE_SUB(time_in, INTERVAL 8 HOUR)) AS build_date FROM cheesy_frc_hours.lab_sessions) AS build_days
-    LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date=build_date
+    build_days LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date=build_date
 ORDER BY build_date ASC;
 """
 
 CALENDAR_BUILD_INFO_QUERY = """
-SELECT
-	filtered_table.build_date,
-		filtered_table.student_id,
-		filtered_table.session_id,
-		COALESCE(filtered_table.sessions_attended_count, 0) AS sessions_attended_count,
-		NOT ISNULL(filtered_table.time_in) AS attended,
-		ISNULL(cheesy_frc_hours.optional_builds.date) AS required,
-		NOT ISNULL(ordered_excused_sessions.date) AS excused
+WITH
+    build_days AS (SELECT DISTINCT DATE(time_in) AS build_date FROM cheesy_frc_hours.lab_sessions WHERE NOT excluded_from_total),
+    ordered_students AS (
+        WITH counts AS (
+            SELECT
+                COUNT(*) as sessions_attended_count,
+                student_id
+            FROM cheesy_frc_hours.lab_sessions
+            GROUP BY student_id
+        )
+        SELECT
+            id as student_id,
+            sessions_attended_count
+        FROM
+            cheesy_frc_hours.students
+        LEFT JOIN counts ON cheesy_frc_hours.students.id=counts.student_id
+    )
+SELECT DISTINCT
+    build_days.build_date,
+    ordered_students.student_id,
+    COALESCE(ordered_students.sessions_attended_count, 0) AS sessions_attended_count,
+    NOT ISNULL(cheesy_frc_hours.lab_sessions.time_in) as attended,
+    ISNULL(cheesy_frc_hours.optional_builds.date) AS required,
+    NOT ISNULL(cheesy_frc_hours.excused_sessions.date) AS excused
 FROM
-	(SELECT DISTINCT
-	build_days.build_date,
-		ordered_students.student_id,
-		filtered_sessions.time_in,
-		ordered_students.sessions_attended_count,
-		filtered_sessions.id AS session_id,
-		filtered_sessions.excluded_from_total
-FROM
-	(SELECT DISTINCT
-	DATE(DATE_SUB(time_in, INTERVAL 8 HOUR)) AS build_date
-FROM
-	cheesy_frc_hours.lab_sessions
-WHERE
-	NOT excluded_from_total) AS build_days
-CROSS JOIN (SELECT
-	id AS student_id, counts.sessions_attended_count
-FROM
-	cheesy_frc_hours.students
-LEFT JOIN (SELECT
-	COUNT(*) AS sessions_attended_count, student_id
-FROM
-	(SELECT DISTINCT
-	time_in, student_id
-FROM
-	cheesy_frc_hours.lab_sessions
-GROUP BY DATE(DATE_SUB(time_in, INTERVAL 8 HOUR)) , student_id) AS condensed_sessions
-GROUP BY student_id) AS counts ON cheesy_frc_hours.students.id = counts.student_id) AS ordered_students
-LEFT JOIN (SELECT
-	time_in, student_id, id, excluded_from_total
-FROM
-	cheesy_frc_hours.lab_sessions) AS filtered_sessions ON filtered_sessions.student_id = ordered_students.student_id
-	AND DATE(DATE_SUB(filtered_sessions.time_in, INTERVAL 8 HOUR)) = build_days.build_date
-	AND NOT filtered_sessions.excluded_from_total) AS filtered_table
-LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date = filtered_table.build_date
-LEFT JOIN (SELECT * FROM cheesy_frc_hours.excused_sessions ORDER BY date ASC, student_id DESC) AS ordered_excused_sessions ON ordered_excused_sessions.student_id=filtered_table.student_id
-	AND ordered_excused_sessions.date=filtered_table.build_date
-GROUP BY build_date, student_id
-ORDER BY build_date ASC , sessions_attended_count DESC , student_id DESC;  -- fallback if students are tied in lab sessions
+    build_days CROSS JOIN ordered_students
+    LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date=build_days.build_date
+    LEFT JOIN cheesy_frc_hours.lab_sessions ON DATE(cheesy_frc_hours.lab_sessions.time_in) = build_days.build_date
+        AND cheesy_frc_hours.lab_sessions.student_id=ordered_students.student_id
+        AND NOT cheesy_frc_hours.lab_sessions.excluded_from_total
+    LEFT JOIN cheesy_frc_hours.excused_sessions ON cheesy_frc_hours.excused_sessions.student_id=ordered_students.student_id
+        AND cheesy_frc_hours.excused_sessions.date=build_days.build_date
+ORDER BY
+    build_date ASC,
+    sessions_attended_count DESC,
+    student_id DESC;  -- fallback if students are tied in lab sessions
 """
-# Note: The above query is incompatible with MySQL 5.7 and greater because
-# the SQL mode "ONLY_FULL_GROUP_BY" became enabled by default. As a workaround,
-# execute a query like "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));"
-# before loading the calendar page, which will temporarily remove this setting.
 
 CALENDAR_STUDENT_INFO_QUERY = """
-SELECT
-        COUNT(IF(required
-                AND (NOT excused OR (excused AND attended)), 1, NULL)) AS required_count,
-            COUNT(IF(attended AND required, 1, NULL)) AS required_attended_count,
-            COUNT(IF(attended, 1, NULL)) AS total_attended_count,
-            student_id
-    FROM
-        (SELECT DISTINCT
-        filtered_table.build_date,
-            filtered_table.student_id,
-            NOT ISNULL(filtered_table.time_in) AS attended,
-            ISNULL(cheesy_frc_hours.optional_builds.date) AS required,
-            NOT ISNULL(ordered_excused_sessions.date) AS excused
-    FROM
-        (SELECT DISTINCT
+WITH build_info AS (
+    WITH
+        build_days AS (SELECT DISTINCT DATE(time_in) AS build_date FROM cheesy_frc_hours.lab_sessions WHERE NOT excluded_from_total)
+    SELECT DISTINCT
         build_days.build_date,
-            cheesy_frc_hours.students.id AS student_id,
-            filtered_sessions.time_in,
-            filtered_sessions.id AS session_id,
-            filtered_sessions.excluded_from_total
+        students.id AS student_id,
+        NOT ISNULL(cheesy_frc_hours.lab_sessions.time_in) as attended,
+        ISNULL(cheesy_frc_hours.optional_builds.date) AS required,
+        NOT ISNULL(cheesy_frc_hours.excused_sessions.date) AS excused
     FROM
-        (SELECT DISTINCT
-        DATE(DATE_SUB(time_in, INTERVAL 8 HOUR)) AS build_date
-    FROM
-        cheesy_frc_hours.lab_sessions
-    WHERE
-        NOT excluded_from_total) AS build_days
-    CROSS JOIN cheesy_frc_hours.students
-    LEFT JOIN (SELECT
-        time_in, student_id, id, excluded_from_total
-    FROM
-        cheesy_frc_hours.lab_sessions) AS filtered_sessions ON filtered_sessions.student_id = cheesy_frc_hours.students.id
-        AND DATE(DATE_SUB(filtered_sessions.time_in, INTERVAL 8 HOUR)) = build_days.build_date
-        AND NOT filtered_sessions.excluded_from_total) AS filtered_table
-    LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date = filtered_table.build_date
-    LEFT JOIN (SELECT * FROM cheesy_frc_hours.excused_sessions ORDER BY date ASC, student_id DESC) AS ordered_excused_sessions ON ordered_excused_sessions.student_id=filtered_table.student_id
-		AND ordered_excused_sessions.date=filtered_table.build_date
-    ORDER BY build_date ASC) AS build_info
+        build_days CROSS JOIN cheesy_frc_hours.students
+        LEFT JOIN cheesy_frc_hours.optional_builds ON cheesy_frc_hours.optional_builds.date=build_days.build_date
+        LEFT JOIN cheesy_frc_hours.lab_sessions ON DATE(cheesy_frc_hours.lab_sessions.time_in) = build_days.build_date
+            AND cheesy_frc_hours.lab_sessions.student_id=cheesy_frc_hours.students.id
+            AND NOT cheesy_frc_hours.lab_sessions.excluded_from_total
+        LEFT JOIN cheesy_frc_hours.excused_sessions ON cheesy_frc_hours.excused_sessions.student_id=cheesy_frc_hours.students.id
+            AND cheesy_frc_hours.excused_sessions.date=build_days.build_date
+        ORDER BY build_date ASC
+), student_build_info AS (
+    SELECT
+        COUNT(IF(required AND (NOT excused OR (excused AND attended)), 1, NULL)) AS required_count,
+        COUNT(IF(attended AND required, 1, NULL)) AS required_attended_count,
+        COUNT(IF(attended, 1, NULL)) AS total_attended_count,
+        student_id
+    FROM build_info
     GROUP BY student_id
-ORDER BY total_attended_count DESC , student_id DESC;
+)
+
+SELECT * FROM student_build_info
+ORDER BY total_attended_count DESC, student_id DESC;
 """

--- a/views/calendar.erb
+++ b/views/calendar.erb
@@ -1,4 +1,5 @@
 <%= erb :header %>
+<% DB.fetch "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));" do end %>
 <div class="container container-wide">
    <div style="display: flex; align-items: center">
    <h2>Calendar</h2>
@@ -8,21 +9,21 @@
    <table style="border: 1px solid #000; height: 38px; border-left: none; border-top-right-radius: 4px; border-bottom-right-radius: 4px;">
       <thead>
          <tr>
-            <th style = "width:70px; height:34px; text-align: center; background-color: var(--missing-color); color: White">Absent</th>
-            <th style = "width:70px; height:34px; text-align: center; background-color: var(--present-color); color: White">Present</th>
-            <th style = "width:70px; height:34px; text-align: center; background-color: var(--excused-color)">Optional</th>
-            <th class="stripe-bg" style = "width:70px; height:34px; --color-a: var(--excused-color); --color-b: var(--partial-color); text-align: center; border-top-right-radius: 4px; border-bottom-right-radius: 4px;">Excused</th>
+            <th style="width:70px; height:34px; text-align: center; background-color: var(--missing-color); color: White">Absent</th>
+            <th style="width:70px; height:34px; text-align: center; background-color: var(--present-color); color: White">Present</th>
+            <th style="width:70px; height:34px; text-align: center; background-color: var(--excused-color)">Optional</th>
+            <th class="stripe-bg" style="width:70px; height:34px; --color-a: var(--excused-color); --color-b: var(--partial-color); text-align: center; border-top-right-radius: 4px; border-bottom-right-radius: 4px;">Excused</th>
          </tr>
       </thead>
    </table>
    </div>
-      <div class = "cheesy-row" style="clear: right">
-        <div style="overflow-x: scroll; padding-bottom: 64px;" class = "column2">
+      <div class="cheesy-row" style="clear: right">
+        <div style="overflow-x: scroll; padding-bottom: 64px;" class="column2">
          <div>
             <table style="table-layout: fixed; margin-bottom: 0px" class="table table-striped table-bordered table-condensed">
                <tr>
-                  <% DB.fetch BUILD_DAYS_QUERY do |build_date|%>
-                        <th style="width:60px; height:45px; padding-left: 0; padding-right: 0; text-align: center" title="<%= build_date[:build_date].strftime("%A, %B %-d, %Y") %>"> 
+                  <% DB.fetch BUILD_DAYS_QUERY do |build_date| %>
+                        <th style="width:60px; height:45px; padding-left: 0; padding-right: 0; text-align: center" title="<%= build_date[:build_date].strftime("%A, %B %-d, %Y") %>">
                            <%= build_date[:build_date].strftime("%m/%d") %>
                            <% if build_date[:optional] == 1 %>
                               <br/>
@@ -35,21 +36,21 @@
                   <% end %>
                </tr>
             </table>
-            <table style="table-layout: fixed;" class="table table-striped table-bordered table-condensed column-based">
-               <%studentsCnt = Student.count%>
-               <%rowNum = 1%>
-               <%DB.fetch CALENDAR_BUILD_INFO_QUERY do |row|%>
-                  <%student_id = row[:student_id]%>
-                  <%session_id = row[:session_id] rescue nil%>
-                  <%build_date = row[:build_date]%>
-                  <%attended = row[:attended]%>
-                  <%required = row[:required]%>
-                  <%excused = row[:excused]%>
-                  <%if (rowNum.modulo(studentsCnt) == 1)%>
+            <table style="table-layout: fixed;" class="table table-striped table-bordered table-condensed column-based" id="color-grid">
+               <% studentsCnt = Student.count %>
+               <% rowNum = 1 %>
+               <% DB.fetch CALENDAR_BUILD_INFO_QUERY do |row| %>
+                   <% student_id = row[:student_id] %>
+                   <% session_id = row[:session_id] rescue nil %>
+                   <% build_date = row[:build_date] %>
+                   <% attended = row[:attended] %>
+                   <% required = row[:required] %>
+                   <% excused = row[:excused] %>
+                  <% if (rowNum.modulo(studentsCnt) == 1) %>
                      <tr style="width: 61px">
-                  <%end%>
-                  <%if (attended == 1)%>
-                     <td style = "background-color: var(--present-color); min-width:50px; height:30px;">
+                  <% end %>
+                  <% if (attended == 1) %>
+                     <td style="background-color: var(--present-color); min-width:50px; height:30px;">
                         <div class="btn-group visible-if-parent-hover">
                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                               <span class="caret"></span>
@@ -60,8 +61,8 @@
                            </ul>
                         </div>
                      </td>
-                  <%elsif (excused == 1 && required == 1)%>
-                     <td style = "--color-a: var(--excused-color); --color-b: var(--partial-color); min-width:50px; height:30px;" class="stripe-bg">
+                  <% elsif (excused == 1 && required == 1) %>
+                     <td style="--color-a: var(--excused-color); --color-b: var(--partial-color); min-width:50px; height:30px;" class="stripe-bg">
                         <div class="btn-group visible-if-parent-hover">
                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                               <span class="caret"></span>
@@ -71,7 +72,7 @@
                            </ul>
                         </div>
                      </td>
-                  <%elsif (!(required == 1))%>
+                  <% elsif (!(required == 1)) %>
                      <td style="background-color: var(--excused-color); min-width:50px; height:30px;">
                         <div class="btn-group visible-if-parent-hover">
                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -82,7 +83,7 @@
                            </ul>
                         </div>
                      </td>
-                  <%else%>
+                  <% else %>
                      <td style = "background-color: var(--missing-color); min-width:50px; height:30px;">
                         <div class="btn-group visible-if-parent-hover">
                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -95,15 +96,15 @@
                         </div>
                      </td>
                   <% end %>
-                  <%if (rowNum.modulo(studentsCnt) == 0)%>
+                  <% if (rowNum.modulo(studentsCnt) == 0) %>
                      </tr>
                   <% end %>
-                  <%rowNum += 1%>
-               <%end%>
+                  <% rowNum += 1 %>
+               <% end %>
             </table>
          </div>
       </div>
-      <div class = "column1">
+      <div class="column1">
             <table style="table-layout: fixed;" class="table table-striped table-bordered table-condensed">
               <tr>
                 <th style="width:65px; height:45px; text-align: center">Builds Attended</th>
@@ -118,12 +119,12 @@
                      <td style="width:65px; height:30px;"><%=row[:total_attended_count]%></td>
                      <td style ="width:80px; height: 30px"><%=(100 * row[:required_attended_count].to_f/row[:required_count]).to_i rescue "0"%>%</td>
                      <td style="width:65px; height:30px;"><%=student.id%> </td>
-                     <td 
+                     <td
                         style="width:200px; height:30px; white-space: nowrap;"
                         title="<%=student.first_name + " " + student.last_name%>"
                      ><a href="/students/<%= student.id %>"><%= student.first_name %> <%= student.last_name %></a></td>
                   </tr>
-              <%end%>
+              <% end %>
             </table>
             <div style="display: flex; gap: 1.5em">
                <% if @user.has_permission?("HOURS_VIEW_REPORT") %>
@@ -134,7 +135,9 @@
         </div>
 </div>
 <script>
-    var left = $('.column2').width();
+    var left = $('.column2').width() * 2;
     $('.column2').scrollLeft(left);
+    $('#color-grid').children().children('tr:nth-last-child(2)').children().children().children(".dropdown-menu").addClass("pull-right")
+    $('#color-grid').children().children('tr:nth-last-child(1)').children().children().children(".dropdown-menu").addClass("pull-right")
 </script>
 <%= erb :footer %>

--- a/views/edit_lab_session.erb
+++ b/views/edit_lab_session.erb
@@ -2,6 +2,7 @@
 
 <script>
   var timeOffset = " -0" + (new Date()).getTimezoneOffset() / 60 + "00";
+  const hasOffsetRe = /.*[\-\+]\d{4}$/
 </script>
 
 <div class="container">
@@ -10,13 +11,13 @@
     <input type="hidden" name="referrer" value="<%= @referrer %>" />
     <label>Time in (e.g. 2014-01-04 13:00:00)</label>
     <input type="text" name="time_in"
-        value="<%= @lab_session.time_in.in_time_zone("America/Los_Angeles") rescue "" %>"
-        onchange="if (!this.value.endsWith(timeOffset)) { this.value = this.value.concat(timeOffset); }"
+        value="<%= @lab_session.time_in.in_time_zone(USER_TIME_ZONE) rescue "" %>"
+        onchange="if (!hasOffsetRe.test(this.value)) { this.value = this.value.concat(timeOffset); }"
         />
     <label>Time out (e.g. 2014-01-04 20:00:00)</label>
     <input type="text" name="time_out"
-        value="<%= @lab_session.time_out.in_time_zone("America/Los_Angeles") rescue "" %>"
-        onchange="if (!this.value.endsWith(timeOffset)) { this.value = this.value.concat(timeOffset); }" 
+        value="<%= @lab_session.time_out.in_time_zone(USER_TIME_ZONE) rescue "" %>"
+        onchange="if (!hasOffsetRe.test(this.value)) { this.value = this.value.concat(timeOffset); }"
         />
     <label>Notes (e.g. description of non-lab work)</label>
     <textarea name="notes"><%= @lab_session.notes rescue "" %></textarea>

--- a/views/mentor_checkins.erb
+++ b/views/mentor_checkins.erb
@@ -14,7 +14,7 @@
         <% @mentor_checkins.each do |checkin| %>
           <tr>
             <td><%= checkin.mentor.first_name %> <%= checkin.mentor.last_name %></td>
-            <td><%= checkin.time_in.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") %></td>
+            <td><%= checkin.time_in.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") %></td>
             <td>
               <span style="white-space: nowrap;">
                 <a href="/mentor_checkins/<%= checkin.id %>/delete" class="btn btn-danger btn-small">Delete</a>

--- a/views/search.erb
+++ b/views/search.erb
@@ -6,7 +6,7 @@
     <label>Leave End Date empty to search for one day.</label>
     <p id="query">
       <input class="form-control input-lg text-input" name="start_date" value="<%= @start %>" placeholder="Start Date (yyyy-mm-dd)" autofocus>
-       to 
+       to
       <input class="form-control input-lg text-input" name="end_date" value="<%= @end %>" placeholder="End Date (yyyy-mm-dd)">
     </p>
     <button type="submit" class="btn btn-success btn-lg" id="scanSubmit">Search</button>
@@ -26,9 +26,9 @@
           <td>
             <a href="/students/<%= session.student.id %>"><%= session.student.first_name %> <%= session.student.last_name %></a>
           </td>
-          <td><%= session.time_in.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") rescue "" %></td>
+          <td><%= session.time_in.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") rescue "" %></td>
           <td>
-            <%= session.time_out.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") rescue "" %>
+            <%= session.time_out.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") rescue "" %>
           </td>
           <td><%= session.duration_hours.round(1) %></td>
           <td><%= session.mentor ? "#{session.mentor.first_name} #{session.mentor.last_name}" :

--- a/views/signed_in_list.erb
+++ b/views/signed_in_list.erb
@@ -18,7 +18,7 @@
       <% else %>
         <td><%= session.student_id %></td>
       <% end %>
-      <td><%= session.time_in.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") %></td>
+      <td><%= session.time_in.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") %></td>
       <% if @user && (@user.has_permission?("HOURS_EDIT") || @user.has_permission?("HOURS_DELETE")) %>
         <td>
           <% if @user.has_permission?("HOURS_EDIT") %>

--- a/views/student.erb
+++ b/views/student.erb
@@ -23,9 +23,9 @@
       </tr>
       <% @student.lab_sessions.sort_by(&:id).each do |session| %>
         <tr>
-          <td><%= session.time_in.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") rescue "" %></td>
+          <td><%= session.time_in.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") rescue "" %></td>
           <td>
-            <%= session.time_out.in_time_zone("America/Los_Angeles").strftime("%D %l:%M %p") rescue "" %>
+            <%= session.time_out.in_time_zone(USER_TIME_ZONE).strftime("%D %l:%M %p") rescue "" %>
           </td>
           <td><%= session.duration_hours.round(1) %></td>
           <td><%= session.mentor ? "#{session.mentor.first_name} #{session.mentor.last_name}" :


### PR DESCRIPTION
Note: these additional fixes were ones I tested earlier, just never submitted a PR for. This PR also fixes the bugs created by the MySQL 8.0 upgrade.

**Changelog:**
- General: Refactor so end-user time zone is in constants.rb (not across multiple files)
- Editing lab sessions: Respect manually-entered timezone offsets that don't match the user's current timezone
- Auto-optionalize: prevent MySQL errors when signing in on offdays under certain circumstances
- Calendar: Keep dropdowns from appearing offscreen
- Calendar: Scroll to furthest right day when loading
- Constants: Add documentation about what each constant is
- Queries: Change to MySQL 8.X-compatible queries
- Remove some trailing whitespace